### PR TITLE
Make 'Sources' column visible by default in all voyages table flatfiles

### DIFF
--- a/src/utils/flatfiles/voyages/voyages_all_table.json
+++ b/src/utils/flatfiles/voyages/voyages_all_table.json
@@ -1486,7 +1486,7 @@
 				"pt": "Fontes"
 			},
 			"cell_type": "literal",
-			"visible": false,
+			"visible": true,
 			"number_format": null,
 			"order_by": [
 				"voyage_source_connections__source__title"

--- a/src/utils/flatfiles/voyages/voyages_indian_ocean_and_asia_slave_trade_database_table.json
+++ b/src/utils/flatfiles/voyages/voyages_indian_ocean_and_asia_slave_trade_database_table.json
@@ -1486,7 +1486,7 @@
 				"pt": "Fontes"
 			},
 			"cell_type": "literal",
-			"visible": false,
+			"visible": true,
 			"number_format": null,
 			"order_by": [
 				"voyage_source_connections__source__title"

--- a/src/utils/flatfiles/voyages/voyages_intraamerican_table.json
+++ b/src/utils/flatfiles/voyages/voyages_intraamerican_table.json
@@ -1509,7 +1509,7 @@
 				"pt": "Fontes"
 			},
 			"cell_type": "literal",
-			"visible": false,
+			"visible": true,
 			"number_format": null,
 			"order_by": [
 				"voyage_source_connections__source__title"

--- a/src/utils/flatfiles/voyages/voyages_transatlantic_table.json
+++ b/src/utils/flatfiles/voyages/voyages_transatlantic_table.json
@@ -1486,7 +1486,7 @@
 				"pt": "Fontes"
 			},
 			"cell_type": "literal",
-			"visible": false,
+			"visible": true,
 			"number_format": null,
 			"order_by": [
 				"voyage_source_connections__source__title"


### PR DESCRIPTION
## Summary

Make the Sources column visible by default across all four voyages database pages (Trans-Atlantic, Intra-American, Indian Ocean, and All Voyages). Changed visible: false to visible: true in the Sources entry of each flatfile:

```
voyages_transatlantic_table.json
voyages_intraamerican_table.json
voyages_indian_ocean_and_asia_slave_trade_database_table.json
voyages_all_table.json
```

## Deployment Instructions

None

## Testing Performed

Voyages tables (Trans-Atlantic, Intra-American, Indian Ocean, and All Voyages) show 'Sources' by default. 

